### PR TITLE
Add star range input

### DIFF
--- a/public/starhollow.svg
+++ b/public/starhollow.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg120"
+   width="28"
+   height="28"
+   viewBox="0 0 28 28"
+   sodipodi:docname="starhollow.svg"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14">
+  <metadata
+     id="metadata126">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs124">
+    <linearGradient
+       id="linearGradient4730"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4728" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1912"
+     inkscape:window-height="1040"
+     id="namedview122"
+     showgrid="false"
+     inkscape:object-paths="false"
+     inkscape:zoom="21.465742"
+     inkscape:cx="4.1884754"
+     inkscape:cy="15.009706"
+     inkscape:window-x="4"
+     inkscape:window-y="4"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg120" />
+  <path
+     style="opacity:1;fill:#ffa500;fill-opacity:0.05555556;stroke:#000000;stroke-width:0.19389799;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     inkscape:transform-center-x="0.012327003"
+     inkscape:transform-center-y="-1.4387464"
+     d="M 22.521121,27.816159 14.015472,22.971148 5.5353885,27.865479 7.2883785,17.860748 0.2419083,10.891212 9.830966,9.5529604 13.956091,0.35122047 18.129463,9.5288658 27.725402,10.811412 20.71563,17.821762 Z"
+     id="path168"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/public/starsolid.svg
+++ b/public/starsolid.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg120"
+   width="28"
+   height="28"
+   viewBox="0 0 28 28"
+   sodipodi:docname="starsolid.svg"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14">
+  <metadata
+     id="metadata126">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs124">
+    <linearGradient
+       id="linearGradient4730"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4728" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1912"
+     inkscape:window-height="1040"
+     id="namedview122"
+     showgrid="false"
+     inkscape:object-paths="false"
+     inkscape:zoom="21.465742"
+     inkscape:cx="4.1884754"
+     inkscape:cy="15.009706"
+     inkscape:window-x="4"
+     inkscape:window-y="4"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg120" />
+  <path
+     style="opacity:1;fill:#ffa500;fill-opacity:1;stroke:#000000;stroke-width:0.19389799;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     inkscape:transform-center-x="0.012327003"
+     inkscape:transform-center-y="-1.4387464"
+     d="M 22.521121,27.816159 14.015472,22.971148 5.5353885,27.865479 7.2883785,17.860748 0.2419083,10.891212 9.830966,9.5529604 13.956091,0.35122047 18.129463,9.5288658 27.725402,10.811412 20.71563,17.821762 Z"
+     id="path168"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/src/components/AddNewReviewForm.tsx
+++ b/src/components/AddNewReviewForm.tsx
@@ -51,7 +51,7 @@ export const AddNewReviewForm = ({
 const StarInput = styled(RangeInput)`
   width: 140px;
   height: 28px
-  z-index: 1;
+  z-index: 2;
   opacity: 0;
   position: absolute;
 `;

--- a/src/components/AddNewReviewForm.tsx
+++ b/src/components/AddNewReviewForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Review } from "../types";
-import { Cell, TextInput, WhiteRow, NumberInput } from "./CommonFormComponents";
+import { Cell, TextInput, WhiteRow, RangeInput } from "./CommonFormComponents";
+import styled from "styled-components";
 
 interface EditReviewRowProps {
   reviewData: Partial<Review>;
@@ -22,9 +23,17 @@ export const AddNewReviewForm = ({
     <WhiteRow>
       <Cell />
       <Cell>
-        <NumberInput
+        <StarDiv
+          style={{ opacity: 0.4, position: "absolute", width: 5 * 28 }}
+        />
+        <StarDiv style={{ width: rating * 28 }} />
+        <RangeInput
           placeholder="Rating"
           name="rating"
+          type="range"
+          min={0}
+          max={5}
+          step={0.1}
           value={rating}
           onChange={newReviewDataChange}
         />
@@ -40,3 +49,9 @@ export const AddNewReviewForm = ({
     </WhiteRow>
   );
 };
+
+const StarDiv = styled.div`
+  background-image: url(https://mdn.mozillademos.org/files/12005/starsolid.gif);
+  background-repeat: repeat-x;
+  height: 28px;
+`;

--- a/src/components/AddNewReviewForm.tsx
+++ b/src/components/AddNewReviewForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Review } from "../types";
-import { Cell, TextInput, WhiteRow, RangeInput } from "./CommonFormComponents";
+import { Cell, TextInput, WhiteRow } from "./CommonFormComponents";
 import styled from "styled-components";
 import { StarRating } from "./StarRating";
 
@@ -48,7 +48,11 @@ export const AddNewReviewForm = ({
   );
 };
 
-const StarInput = styled(RangeInput)`
+interface InputProps {
+  onChange: any;
+}
+
+const StarInput = styled.input<InputProps>`
   width: 140px;
   height: 28px
   z-index: 2;

--- a/src/components/AddNewReviewForm.tsx
+++ b/src/components/AddNewReviewForm.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Review } from "../types";
 import { Cell, TextInput, WhiteRow, RangeInput } from "./CommonFormComponents";
 import styled from "styled-components";
+import { StarRating } from "./StarRating";
 
 interface EditReviewRowProps {
   reviewData: Partial<Review>;
@@ -23,11 +24,7 @@ export const AddNewReviewForm = ({
     <WhiteRow>
       <Cell />
       <Cell>
-        <StarDiv
-          style={{ opacity: 0.4, position: "absolute", width: 5 * 28 }}
-        />
-        <StarDiv style={{ width: rating * 28 }} />
-        <RangeInput
+        <StarInput
           placeholder="Rating"
           name="rating"
           type="range"
@@ -37,6 +34,7 @@ export const AddNewReviewForm = ({
           value={rating}
           onChange={newReviewDataChange}
         />
+        <StarRating rating={rating} />
       </Cell>
       <Cell>
         <TextInput
@@ -50,8 +48,10 @@ export const AddNewReviewForm = ({
   );
 };
 
-const StarDiv = styled.div`
-  background-image: url(https://mdn.mozillademos.org/files/12005/starsolid.gif);
-  background-repeat: repeat-x;
-  height: 28px;
+const StarInput = styled(RangeInput)`
+  width: 140px;
+  height: 28px
+  z-index: 1;
+  opacity: 0;
+  position: absolute;
 `;

--- a/src/components/CommonFormComponents.tsx
+++ b/src/components/CommonFormComponents.tsx
@@ -57,4 +57,4 @@ interface RangeProps {
   step: number;
 }
 
-export var RangeInput: (props: RangeProps) => any = styled.input``;
+export var RangeInput = styled.input<RangeProps>``;

--- a/src/components/CommonFormComponents.tsx
+++ b/src/components/CommonFormComponents.tsx
@@ -45,16 +45,3 @@ interface TextInputProps {
 export var TextInput: (props: TextInputProps) => any = styled.input`
   width: 100%;
 `;
-
-interface RangeProps {
-  placeholder: string;
-  value: number;
-  onChange: any;
-  name: string;
-  type: string;
-  max: number;
-  min: number;
-  step: number;
-}
-
-export var RangeInput = styled.input<RangeProps>``;

--- a/src/components/CommonFormComponents.tsx
+++ b/src/components/CommonFormComponents.tsx
@@ -46,11 +46,15 @@ export var TextInput: (props: TextInputProps) => any = styled.input`
   width: 100%;
 `;
 
-interface NumberProps {
+interface RangeProps {
   placeholder: string;
   value: number;
   onChange: any;
   name: string;
+  type: string;
+  max: number;
+  min: number;
+  step: number;
 }
 
-export var NumberInput: (props: NumberProps) => any = styled.input``;
+export var RangeInput: (props: RangeProps) => any = styled.input``;

--- a/src/components/PlaceController.tsx
+++ b/src/components/PlaceController.tsx
@@ -52,8 +52,6 @@ export const PlaceController = ({ match }: Props) => {
     if (!event.target.name) {
       throw new Error("No name on event.target");
     }
-    console.log(event.target.name);
-    console.log(event.target.value);
     setNewReview({ ...newReview, [event.target.name]: event.target.value });
   };
 

--- a/src/components/StarRating.tsx
+++ b/src/components/StarRating.tsx
@@ -12,7 +12,7 @@ export const StarRating = (props: Props) => {
   return (
     <>
       <StarDiv style={{ width: rating * 28 }} />
-      <EmptyStarDiv style={{ width: 5 * 28 }} />
+      <HollowStarDiv style={{ width: 5 * 28 }} />
     </>
   );
 };
@@ -25,7 +25,7 @@ const StarDiv = styled.div`
   z-index: 1;
 `;
 
-const EmptyStarDiv = styled.div`
+const HollowStarDiv = styled.div`
   background-image: url(/starhollow.svg);
   background-repeat: repeat-x;
   height: 28px;

--- a/src/components/StarRating.tsx
+++ b/src/components/StarRating.tsx
@@ -1,51 +1,33 @@
 import React from "react";
-import FontAwesome from "react-fontawesome";
 import styled from "styled-components";
-
-interface StarProps {
-  key: string;
-  filled: number; // Star fills according to rules: empty < 0.25 <= half < 0.75 <= Full
-}
-
-const Star = ({ filled }: StarProps) => {
-  if (0.75 <= filled) {
-    return <YellowStar />;
-  } else if (0.25 <= filled && filled < 0.75) {
-    return <YellowHalfStar />;
-  }
-  return <YellowHollowStar />;
-};
+import _ from "lodash";
 
 interface Props {
   rating: number;
 }
 
 export const StarRating = (props: Props) => {
-  const rating = props.rating;
+  const rating = _.min([5, props.rating]) || 0;
 
   return (
     <>
-      {[0, 1, 2, 3, 4].map(i => (
-        <Star key={`${i}`} filled={rating - i} />
-      ))}
+      <StarDiv style={{ width: rating * 28 }} />
+      <EmptyStarDiv style={{ width: 5 * 28 }} />
     </>
   );
 };
 
-const HalfGreyStar = (props: any) => (
-  <FontAwesome {...props} name="star-half-o" />
-);
-
-const YellowHalfStar = styled(HalfGreyStar)`
-  color: rgb(255, 180, 0);
+const StarDiv = styled.div`
+  background-image: url(/starsolid.svg);
+  background-repeat: repeat-x;
+  height: 28px;
+  position: absolute;
+  z-index: 1;
 `;
 
-const GreyStar = (props: any) => <FontAwesome {...props} name="star" />;
-const YellowStar = styled(GreyStar)`
-  color: rgb(255, 180, 0);
-`;
-
-const HollowStar = (props: any) => <FontAwesome {...props} name="star-o" />;
-const YellowHollowStar = styled(HollowStar)`
-  color: rgb(255, 180, 0);
+const EmptyStarDiv = styled.div`
+  background-image: url(/starhollow.svg);
+  background-repeat: repeat-x;
+  height: 28px;
+  z-index: 0;
 `;


### PR DESCRIPTION
Also made all stars look the same.

![2019-03-28-215353_966x1002_scrot](https://user-images.githubusercontent.com/2412457/55192110-0dd41500-51a4-11e9-9467-03dac12b3cb7.png)
![2019-03-28-215404_963x686_scrot](https://user-images.githubusercontent.com/2412457/55192112-0dd41500-51a4-11e9-8cd0-835be74e95d7.png)

But I have to admit, the solution is a bit dirty.  Hides a range slider (with `opacity: 0`) behind the x-repeating backgrounds of the stars.  But, a slider will always work, right? No need to do any manual mouse click/drag code.