### PR TITLE
Remove extra width on modals

### DIFF
--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -9,6 +9,8 @@
   min-height: 100%;
   padding-bottom: 71px;
   overflow: scroll;
+  display: flex;
+  align-items: flex-start;
 }
 
 .modal-container {


### PR DESCRIPTION
Before:
![2019-05-12-201807_1024x644_scrot](https://user-images.githubusercontent.com/2412457/57586234-509f4180-74f3-11e9-83ea-a3b1e64da6a7.png)

After:
![2019-05-12-201037_858x641_scrot](https://user-images.githubusercontent.com/2412457/57586240-59901300-74f3-11e9-831f-ffc6f87e5824.png)
